### PR TITLE
Typo change

### DIFF
--- a/Tutorial 1/Tutorial_1.md
+++ b/Tutorial 1/Tutorial_1.md
@@ -148,7 +148,7 @@ Basic Functions
 Working Directories
 -------------------
 
--   Create a new file on your desktop and name it **R Tutorials**.
+-   Create a new folder on your desktop and name it **R Tutorials**.
 
 -   This is where you will save all your work from this course.
 

--- a/Tutorial 2/Tutorial_2.md
+++ b/Tutorial 2/Tutorial_2.md
@@ -167,7 +167,7 @@ Editing Data in Matrix
 -   The code below shows how to make the necessary charges to the matrix.
 
 ``` r
-testScores[,"Jan"]= testScores[,"Jan"]+5
+testScores[,"Jan"] <- testScores[,"Jan"]+5
 testScores
 ```
 

--- a/Tutorial Rmd files/Tutorial 1.Rmd
+++ b/Tutorial Rmd files/Tutorial 1.Rmd
@@ -142,7 +142,7 @@ numberVector[c(1,3:5)]
 
 
 ## Working Directories
-- Create a new file on your desktop and name it **R Tutorials**.
+- Create a new folder on your desktop and name it **R Tutorials**.
 
 - This is where you will save all your work from this course.
 

--- a/Tutorial Rmd files/Tutorial 2.Rmd
+++ b/Tutorial Rmd files/Tutorial 2.Rmd
@@ -130,7 +130,7 @@ apply(testScores, 2, mean)
 - The code below shows how to make the necessary charges to the matrix.
 
 ```{r}
-testScores[,"Jan"]= testScores[,"Jan"]+5
+testScores[,"Jan"] <- testScores[,"Jan"]+5
 testScores
 ```
 


### PR DESCRIPTION
Updated one type, and changed one = to <-, the equals confused a couple of people.

It looks like I changed the whole file but I think it's a whitespace issue. There should be a way to view the changes while ignoring whitespace difference. I have a feeling the whitespace diff might be a windows/mac thing.